### PR TITLE
yt update: separately install yt_astro_analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Python](https://img.shields.io/badge/python-3.9-blue)](https://www.python.org/downloads/)
 [![yt](https://img.shields.io/badge/yt-4.0.2-blue)](https://yt-project.org/)
+[![yt_astro_analysis](https://yt-astro-analysis.readthedocs.io/en/latest/)](https://yt-project.org/)
 [![radmc3dPy](https://img.shields.io/badge/radmc3dPy-0.30.2-blue)](https://www.ita.uni-heidelberg.de/~dullemond/software/radmc-3d/manual_rmcpy/index.html)
 [![matplotlib](https://img.shields.io/badge/matplotlib-3.5.0-blue)](https://matplotlib.org/)
 [![numpy](https://img.shields.io/badge/numpy-4.0.2-blue)](https://numpy.org/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 matplotlib==3.5.0
 numpy==1.20.3
 yt==4.0.2
+yt_astro_analysis==1.1.2
 radmc3dPy==0.30.2
 radmc3d==2.0

--- a/src/writer_gizmo_carver.py
+++ b/src/writer_gizmo_carver.py
@@ -21,7 +21,7 @@ import numpy as np
 import yt
 from astropy import constants as const
 from yt.utilities.lib.write_array import write_3D_array, write_3D_vector_array # same as carver_CarveOut
-from yt.extensions.astro_analysis.radmc3d_export.RadMC3DInterface import RadMC3DLayer, RadMC3DSource
+from yt_astro_analysis.radmc3d_export.RadMC3DInterface import RadMC3DLayer, RadMC3DSource
 
 class RadMC3DWriter_Gizmo:
     


### PR DESCRIPTION
Newer versions of yt just come with a template for astro analyses. One has to separately install `yt_astro_analysis` and then import it in gizmo_carver for gizmo_carver to work.